### PR TITLE
Change read filtering options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         profile_flags: [
         'test',
         'test --skip_trim_adapters',
-        'test --skip_filter_ref',
+        'test',
         'test --save_sars2_filtered_reads',
         'test_fasta_reads',
         'test_single_end',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         profile_flags: [
         'test',
         'test --skip_trim_adapters',
-        'test',
         'test --save_sars2_filtered_reads',
         'test_fasta_reads',
         'test_single_end',

--- a/conf/artic.config
+++ b/conf/artic.config
@@ -2,4 +2,6 @@
 
 params {
 	primers = "https://raw.githubusercontent.com/czbiohub/sc2-illumina-pipeline/master/data/nCoV-2019.bed"
+        prefilter_host_reads = false
+        save_sars2_filtered_reads = true
 }

--- a/conf/benchmark.config
+++ b/conf/benchmark.config
@@ -8,3 +8,5 @@ params {
   // TODO: publically accessible location
   kraken2_db = 's3://jackkamm/covidseq/kraken2_h+v_20200319/'
 }
+
+includeConfig 'msspe.config'

--- a/conf/fasta_reads.config
+++ b/conf/fasta_reads.config
@@ -2,5 +2,4 @@ params {
   single_end = true
   skip_trim_adapters = true
   no_reads_quast = true
-  skip_filter_ref = true
 }

--- a/conf/msspe.config
+++ b/conf/msspe.config
@@ -2,4 +2,6 @@
 
 params {
 	primers = "https://raw.githubusercontent.com/czbiohub/sc2-illumina-pipeline/master/data/SARS-COV-2_spikePrimers.bed"
+        prefilter_host_reads = true
+        save_sars2_filtered_reads = false
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -27,6 +27,7 @@ params {
 
   fasta = 'https://github.com/czbiohub/test-datasets/raw/msspe/reference/MN908947.3.fa'
   ref_host = "$baseDir/data/human_chr1.fa"
-  primers = 'https://github.com/czbiohub/test-datasets/raw/msspe/reference/SARS-COV-2_spikePrimers.bed'
   joint_variant_calling = true
 }
+
+includeConfig 'msspe.config'

--- a/conf/test_fasta_reads.config
+++ b/conf/test_fasta_reads.config
@@ -24,9 +24,9 @@ params {
   ref = "$baseDir/data/MN908947.3.fa"
   ref_host = "$baseDir/data/human_chr1.fa"
   ref_gb = "$baseDir/data/MN908947.3.gb"
-  primers = "$baseDir/data/SARS-COV-2_spikePrimers.bed"
   no_reads_quast = true
   blast_sequences = "$baseDir/data/test/ncov-example-data-sequences.fasta"
 }
 
 includeConfig 'fasta_reads.config'
+includeConfig 'msspe.config'

--- a/conf/test_single_end.config
+++ b/conf/test_single_end.config
@@ -12,5 +12,6 @@ params {
     outdir = 'results/test_single_end'
     fasta = 'https://github.com/czbiohub/test-datasets/raw/msspe/reference/MN908947.3.fa'
     ref_host = 'data/human_chr1.fa'
-    primers = 'https://github.com/czbiohub/test-datasets/raw/msspe/reference/SARS-COV-2_spikePrimers.bed'
 }
+
+includeConfig 'msspe.config'

--- a/docs/output.md
+++ b/docs/output.md
@@ -55,12 +55,16 @@ outdir
 ├── coverage-plots
 │   ├── sample1.depths.png
 │   └── ...
+├── host-subtracted-reads			# optional
+│   ├── sample1_covid_no_host_1.fq.gz
+│   ├── sample1_covid_no_host_2.fq.gz
+│   └── ...
 ├── ercc-stats
 │   ├── sample1.ercc_stats
 │   └── ...
 ├── filtered-sars2-reads			# optional
-│   ├── sample1_covid_1_val_1.fq.gz
-│   ├── sample1_covid_2_val_2.fq.gz
+│   ├── sample1_covid_1.fq.gz
+│   ├── sample1_covid_2.fq.gz
 │   └── ...
 ├── sample-variants
 │   ├── sample1.bcftools_stats
@@ -149,9 +153,13 @@ Line plots of coverage for each sample.
 
 The outputs of `samtools stats` on the alignments to the file `--ercc_fasta`.
 
+## `host-subtracted-reads/`
+
+This folder is created when the flag `--prefilter_host_reads` is set. By default, it is disabled when `-profile artic`, but enabled when `-profile msspe`. It contains untrimmed reads that don't map to the host genome.
+
 ## `filtered-sars2-reads/`
 
-This folder is only created when the flag `--save_sars2_filtered_reads` is set. It contains untrimmed reads that are host-filtered and map to the reference genome.
+This folder is created when the flag `--save_sars2_filtered_reads` is set. By default, it is enabled when `-profile artic`, but disabled when `-profile msspe`. It contains untrimmed reads that map to the reference genome, and filtered of reads that map to host or other viruses.
 
 ## `sample-variants/`
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,7 @@
 <!-- MarkdownTOC -->
 
 - [Processes](#processes)
-	- [`filterRefReads`](#filterrefreads)
+	- [`prefilterHostReads`](#prefilterhostreads)
 	- [`quantifyERCCs`](#quantifyerccs)
 	- [`filterReads`](#filterreads)
 	- [`trimReads`](#trimreads)
@@ -21,9 +21,13 @@
 <!-- /MarkdownTOC -->
 ## Processes
 
-### `filterRefReads`
+### `prefilterHostReads`
 
-Filters host reads by mapping with `minimap2` to the file given with `--ref_host` and keeping unmapped reads. This process can be skipped with the flag `--skip_filter_ref`. The filtered reads will be output into the folder `filtered-reads`. These reads are send to [`filterReads`](#filterreads).
+Filters host reads by mapping with `minimap2` to the file given with `--ref_host` and keeping unmapped reads. This process is optional; enable it with the flag `--prefilter_host_reads`. The filtered reads will be output into the folder `host-subtracted-reads`. These reads are sent to [`filterReads`](#filterreads).
+
+This step may be computationally expensive. If you only need the SARS-CoV-2 reads, and don't care about reads from other pathogens, you can use the fastqs output from `filterReads` instead.
+
+By default, this step is skipped for `-profile artic`, but enabled for `-profile msspe`.
 
 ### `quantifyERCCs`
 
@@ -32,6 +36,8 @@ Quantify ERCC reads by mapping with `minimap2` to the file given with `--ercc_fa
 ### `filterReads`
 
 Filter for only SARS-CoV-2 reads. This is accomplished by first mapping with `minimap2` to the file given with `--ref` and only keeping mapped reads. These reads are then run through `kraken2` against the database provided by `--kraken2_db`. Only reads that are assigned uniquely to SARS-CoV-2 are kept. These reads are sent to [`trimReads`](#trimreads).
+
+When the option `--save_sars2_filtered_reads` is enabled, the fastqs of filtered reads are saved to `filtered-sars2-reads`. By default, this option is enabled when `-profile artic`, but disabled when `-profile msspe`.
 
 ### `trimReads`
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -14,7 +14,7 @@
 	- [`--exclude_samples`](#--exclude_samples)
 	- [`--single_end`](#--single_end)
 	- [`--skip_trim_adapters`](#--skip_trim_adapters)
-	- [`--skip_filter_ref`](#--skip_filter_ref)
+	- [`--prefilter_host_reads`](#--prefilter_host_reads)
 	- [`--maxNs`](#--maxns)
 	- [`--minLength`](#--minlength)
 	- [`--no_reads_quast`](#--no_reads_quast)
@@ -168,9 +168,9 @@ Use this to specify that the reads are single-end.
 
 Use this to skip trimming with Trim Galore. This is useful if you are running on a set of reads that have already been adapter-trimmed. This will __not__ skip primer trimming.
 
-### `--skip_filter_ref`
+### `--prefilter_host_reads`
 
-Use this to skip host-filtering. This is useful to speed up the pipeline for ARTIC read data.
+Prefilter host reads, and save the resulting fastqs. This is useful when you need fastqs that have been filtered of human reads, but still contain reads from other pathogens besides SARS-CoV-2. By default, this is enabled when `-profile artic`, but disabled when `-profile msspe`.
 
 ### `--maxNs`
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -170,7 +170,7 @@ Use this to skip trimming with Trim Galore. This is useful if you are running on
 
 ### `--prefilter_host_reads`
 
-Prefilter host reads, and save the resulting fastqs. This is useful when you need fastqs that have been filtered of human reads, but still contain reads from other pathogens besides SARS-CoV-2. By default, this is enabled when `-profile artic`, but disabled when `-profile msspe`.
+Prefilter host reads, and save the resulting fastqs. This is useful when you need fastqs that have been filtered of human reads, but still contain reads from other pathogens besides SARS-CoV-2. By default, this is disabled when `-profile artic`, but enabled when `-profile msspe`.
 
 ### `--maxNs`
 

--- a/main.nf
+++ b/main.nf
@@ -20,7 +20,7 @@ def helpMessage() {
       --exclude_samples             comma-separated string of samples to exclude from analysis
       --single_end [bool]           Specifies that the input is single-end reads
       --skip_trim_adapters [bool]   Skip trimming of illumina adapters. (NOTE: this does NOT skip the step for trimming spiked primers)
-      --skip_filter_ref             Skip host-filtering.
+      --prefilter_host_reads        Prefilter host reads and save the fastqs.
       --maxNs                       Max number of Ns to allow assemblies to pass QC
       --minLength                   Minimum base pair length to allow assemblies to pass QC
       --no_reads_quast              Run QUAST without aligning reads
@@ -72,7 +72,7 @@ reads_ch = reads_ch.filter { !exclude_samples.contains(it[0]) }
 reads_ch.into { unaligned_reads; stats_reads; ercc_in}
 reads_ch = unaligned_reads
 
-if (params.skip_filter_ref) {
+if (!params.prefilter_host_reads) {
     // skip trimming
     reads_to_remove_host_in = Channel.empty()
 } else {
@@ -81,10 +81,10 @@ if (params.skip_filter_ref) {
     reads_ch = Channel.empty()
 }
 
-process filterRefReads {
+process prefilterHostReads {
     tag { sampleName }
     label 'process_large'
-    publishDir "${params.outdir}/filtered-reads"
+    publishDir "${params.outdir}/host-subtracted-reads"
 
     input:
     path(ref_host)

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ params {
 
   single_end = false
   skip_trim_adapters = false
-  skip_filter_ref = false
+  prefilter_host_reads = false
   readPaths = false
   save_sars2_filtered_reads = false
 
@@ -152,6 +152,6 @@ manifest {
   description = 'Generate consensus SARS-CoV-2 genomes from FASTQ files'
   mainScript = 'main.nf'
   nextflowVersion = '>=19.10.0'
-  version = '1.1'
+  version = '2.0'
 }
 


### PR DESCRIPTION
This PR changes some options and default values when it comes to filtering reads. Since it is backwards-incompatible, the pipeline major version is also bumped to 2.0.

First of all, `--save_sars2_filtered_reads` is now enabled by default when `-profile artic`. It is disabled by default when `-profile msspe`.

Secondly, the `--skip_filter_ref` option has been removed. Instead the option `--prefilter_host_reads` has been added. Note the new option has the opposite meaning. `--prefilter_host_reads` is enabled by default when `-profile msspe`, but disabled by default when `-profile artic`.

When `--prefilter_host_reads` is enabled, the host-subtracted reads are now published to `host-subtracted-reads/` instead of `filtered-reads/`.

