### PR TITLE
Add ability to use czbiohub_aws config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,15 @@ params {
 
 // Output documentation
   multiqc_config = "$baseDir/assets/multiqc_config.yaml"
+  custom_config_version = 'master'
+  custom_config_base = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
+}
 
+// Load nf-core custom profiles from different Institutions
+try {
+  includeConfig "${params.custom_config_base}/nfcore_custom.config"
+} catch (Exception e) {
+  System.err.println("WARNING: Could not load nf-core/config profiles: ${params.custom_config_base}/nfcore_custom.config")
 }
 
 // Function to ensure that resource requirements don't go beyond
@@ -151,4 +159,3 @@ manifest {
   nextflowVersion = '>=19.10.0'
   version = '2.1.0'
 }
-


### PR DESCRIPTION
# czbiohub/sc2-illumina-pipeline pull request

This PR adds the ability to access the configs listed at [nf-core/configs](https://github.com/nf-core/configs/blob/master/nfcore_custom.config), including `czbiohub_aws`:

```
nextflow run czbiohub/sc2-illumina-pipeline -profile test,czbiohub_aws -with-tower
```

We can also add/update configurations as necessary

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [czbiohub/sc2-illumina-pipeline branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/czbiohub/sc2-illumina-pipeline)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/czbiohub/sc2-illumina-pipeline/tree/master/.github/CONTRIBUTING.md)
