### PR TITLE
increase upper threshold of max mutations allowed

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -38,7 +38,7 @@ params {
 
   // qc and filtering
   minLength = 27500
-  maxRefSnps = 30
+  maxRefSnps = 100
   maxAmbiguous = 50
   no_reads_quast = false
 


### PR DESCRIPTION
- `maxRefSnps` sets an upper limit of how many mutations a genome can have. It is used to remove genomes with too many mutations that is not biologically possible given how long the virus has been in existence. The current `maxRefSnps` of 30 was set 6 months ago. Covid has a mutation rate of 2 mutations/month so we're starting to see genomes with around 30 mutations and we need to bump up this number.
- However this filter is only used to create `filtered.fa` which we drag and drop to Nextclade and `filtered.stats` which we don't use anymore. 
- This filter is not used in `set_consensus_genome_status` or `set_status.py`. So in effect, we don't pass or fail genomes with this parameter. 
- Combining the previous 2 points => if there are genomes with high number of mutations, they may not show up in Nextclade b/c of this filter, and we still submit them to public repo b/c not using this filter XD
- To bring these 2 sets of code in alignment, I'll set this number high for now so it doesn't do anything. But need to keep in mind when implement in Aspen.
